### PR TITLE
gl-rs backend part

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,14 @@ name = "demo_glium"
 [[example]]
 name = "demo_wgpu"
 
+[[example]]
+name = "demo_gl"
+
 [features]
 default = ["image"]
 glium_backend = ["glium"]
 wgpu_backend = ["wgpu", "futures", "bytemuck" ]
+gl_backend = ["gl", "glutin", "memoffset"]
 
 [dependencies]
 log = { version = "0.4" }
@@ -49,6 +53,9 @@ glium = { version = "0.28", optional = true }
 wgpu = { version = "0.6", optional = true }
 futures = { version = "0.3", optional = true }
 bytemuck = { version = "1", optional = true }
+gl = {version="0.14", optional = true}
+glutin = {version = "0.26.0", optional = true}
+memoffset = {version = "0.5", optional = true}
 
 [dev-dependencies]
 image = { version = "0.23", default_features = false, features = [ "png" ] }

--- a/examples/demo_gl.rs
+++ b/examples/demo_gl.rs
@@ -1,0 +1,218 @@
+use glutin;
+use glutin::event::{ElementState, Event, MouseButton, MouseScrollDelta, WindowEvent};
+use glutin::event_loop::ControlFlow;
+use std::os::raw::c_char;
+use thyme::{bench, Align, Point};
+use thyme::{Context, InputModifiers};
+
+mod demo;
+
+struct IOData {
+    scale_factor: f32,
+    display_size: Point,
+}
+
+impl thyme::IO for IOData {
+    fn scale_factor(&self) -> f32 {
+        self.scale_factor
+    }
+
+    fn display_size(&self) -> Point {
+        self.display_size
+    }
+}
+
+impl IOData {
+    pub fn handle_event<T>(&mut self, context: &mut Context, event: &Event<T>) {
+        let event = match event {
+            Event::WindowEvent { event, .. } => event,
+            _ => return,
+        };
+
+        use WindowEvent::*;
+        match event {
+            Resized(size) => {
+                let (x, y): (u32, u32) = (*size).into();
+                let size: Point = (x as f32, y as f32).into();
+                self.display_size = size;
+                context.set_display_size(size);
+            }
+            ModifiersChanged(m) => {
+                context.set_input_modifiers(InputModifiers {
+                    shift: m.shift(),
+                    ctrl: m.ctrl(),
+                    alt: m.alt(),
+                });
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                let scale = *scale_factor as f32;
+                self.scale_factor = scale;
+                context.set_scale_factor(scale);
+            }
+            MouseInput { state, button, .. } => {
+                let pressed = match state {
+                    ElementState::Pressed => true,
+                    ElementState::Released => false,
+                };
+
+                let index: usize = match button {
+                    MouseButton::Left => 0,
+                    MouseButton::Right => 1,
+                    MouseButton::Middle => 2,
+                    MouseButton::Other(index) => *index as usize + 3,
+                };
+
+                context.set_mouse_pressed(pressed, index);
+            }
+            MouseWheel { delta, .. } => {
+                match delta {
+                    MouseScrollDelta::LineDelta(x, y) => {
+                        // TODO configure line delta
+                        context.add_mouse_wheel(Point::new(*x * 10.0, *y * 10.0));
+                    }
+                    MouseScrollDelta::PixelDelta(pos) => {
+                        let x = pos.x as f32;
+                        let y = pos.y as f32;
+                        context.add_mouse_wheel(Point::new(x, y));
+                    }
+                }
+            }
+            CursorMoved { position, .. } => {
+                context.set_mouse_pos(
+                    (
+                        position.x as f32 / self.scale_factor,
+                        position.y as f32 / self.scale_factor,
+                    )
+                        .into(),
+                );
+            }
+            ReceivedCharacter(c) => {
+                context.push_character(*c);
+            }
+            _ => (),
+        }
+    }
+}
+
+const OPENGL_MAJOR_VERSION: u8 = 3;
+const OPENGL_MINOR_VERSION: u8 = 2;
+
+#[no_mangle]
+pub extern "system" fn debug_callback(
+    _: gl::types::GLenum,
+    err_type: gl::types::GLenum,
+    id: gl::types::GLuint,
+    severity: gl::types::GLenum,
+    _: gl::types::GLsizei,
+    message: *const c_char,
+    _: *mut std::ffi::c_void,
+) {
+    match err_type {
+        gl::DEBUG_TYPE_ERROR | gl::DEBUG_TYPE_UNDEFINED_BEHAVIOR => unsafe {
+            let err_text = std::ffi::CStr::from_ptr(message);
+            println!(
+                "Type: {:?} ID: {:?} Severity: {:?}:\n  {:#?}",
+                err_type,
+                id,
+                severity,
+                err_text.to_str().unwrap()
+            );
+        },
+        _ => {}
+    }
+}
+
+/// A basic RPG character sheet, using the wgpu backend.
+/// This file contains the application setup code and wgpu specifics.
+/// the `demo.rs` file contains the Thyme UI code and logic.
+/// A simple party creator and character sheet for an RPG.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // initialize our very basic logger so error messages go to stdout
+    thyme::log::init(log::Level::Warn).unwrap();
+
+    // create glium display
+    let event_loop = glutin::event_loop::EventLoop::new();
+    let window_builder = glutin::window::WindowBuilder::new()
+        .with_title("Hello world!")
+        .with_inner_size(glutin::dpi::LogicalSize::new(1280.0, 720.0));
+
+    let windowed_context = glutin::ContextBuilder::new()
+        .with_gl(glutin::GlRequest::Specific(
+            glutin::Api::OpenGl,
+            (OPENGL_MAJOR_VERSION, OPENGL_MINOR_VERSION),
+        ))
+        .build_windowed(window_builder, &event_loop)
+        .unwrap();
+
+    let windowed_context = unsafe { windowed_context.make_current().unwrap() };
+
+    // hide the default cursor
+    windowed_context.window().set_cursor_visible(false);
+    let _gl = {
+        let gl_context = windowed_context.context();
+        gl::load_with(|ptr| gl_context.get_proc_address(ptr) as *const _)
+    };
+
+    if OPENGL_MAJOR_VERSION >= 4 && OPENGL_MINOR_VERSION >= 3 {
+        // Debug message callback is only available since 4.3
+        // Not critical since shader info (what we are most interested in)
+        // is supported in lower versions anyway.
+        unsafe { gl::DebugMessageCallback(Some(debug_callback), std::ptr::null()) };
+    }
+
+    // create thyme backend
+    let mut renderer = thyme::GLRenderer::new();
+    let mut context_builder = thyme::ContextBuilder::with_defaults();
+
+    demo::register_assets(&mut context_builder);
+
+    let mut io = IOData {
+        scale_factor: 1.0,
+        display_size: Point::new(1280.0, 780.0),
+    };
+    let mut context = context_builder.build(&mut renderer, &mut io)?;
+    let mut party = demo::Party::default();
+
+    let mut last_frame = std::time::Instant::now();
+    let frame_time = std::time::Duration::from_millis(16);
+
+    // run main loop
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::MainEventsCleared => {
+            if std::time::Instant::now() > last_frame + frame_time {
+                windowed_context.window().request_redraw();
+            }
+            *control_flow = ControlFlow::WaitUntil(last_frame + frame_time);
+        }
+        Event::RedrawRequested(_) => {
+            last_frame = std::time::Instant::now();
+
+            party.check_context_changes(&mut context, &mut renderer);
+
+            renderer.clear_color(0.21404, 0.21404, 0.21404, 1.0); // manual sRGB conversion for 0.5
+
+            bench::run("thyme", || {
+                let mut ui = context.create_frame();
+
+                bench::run("frame", || {
+                    // show a custom cursor.  it automatically inherits mouse presses in its state
+                    ui.set_mouse_cursor("gui/cursor", Align::TopLeft);
+                    demo::build_ui(&mut ui, &mut party);
+                });
+
+                bench::run("draw", || {
+                    renderer.draw_frame(ui);
+                });
+            });
+
+            windowed_context.swap_buffers().unwrap();
+        }
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => *control_flow = ControlFlow::Exit,
+        event => {
+            io.handle_event(&mut context, &event);
+        }
+    })
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -389,28 +389,36 @@ impl Context {
         &self.internal
     }
 
-    pub(crate) fn set_scale_factor(&mut self, scale: f32) {
+    /// Change the scale factor
+    pub fn set_scale_factor(&mut self, scale: f32) {
         let mut internal = self.internal.borrow_mut();
         internal.scale_factor = scale;
     }
 
-    pub(crate) fn set_display_size(&mut self, size: Point) {
+    /// Set the display size
+    pub fn set_display_size(&mut self, size: Point) {
         let mut internal = self.internal.borrow_mut();
         internal.display_size = size;
     }
 
-    pub(crate) fn add_mouse_wheel(&mut self, delta: Point) {
+    /// Add mouse wheel event.
+    pub fn add_mouse_wheel(&mut self, delta: Point) {
         let mut internal = self.internal.borrow_mut();
 
         internal.mouse_wheel = internal.mouse_wheel + delta;
     }
 
-    pub(crate) fn set_input_modifiers(&mut self, input_modifiers: InputModifiers) {
+    /// Set the input modifiers. You should call this per frame.
+    pub fn set_input_modifiers(&mut self, input_modifiers: InputModifiers) {
         let mut internal = self.internal.borrow_mut();
         internal.input_modifiers = input_modifiers;
     }
 
-    pub(crate) fn set_mouse_pressed(&mut self, pressed: bool, index: usize) {
+    /// Set the mouse pressed state.
+    /// # Inputs:
+    /// - button `pressed` state
+    /// - index: 0 = LeftClick, 1 = Right Click, 2 = Middle Click
+    pub fn set_mouse_pressed(&mut self, pressed: bool, index: usize) {
         let mut internal = self.internal.borrow_mut();
 
         if index >= internal.mouse_pressed.len() {
@@ -434,7 +442,8 @@ impl Context {
         internal.mouse_pressed[index] = pressed;
     }
 
-    pub(crate) fn push_character(&mut self, c: char) {
+    /// Push a character
+    pub fn push_character(&mut self, c: char) {
         let mut internal = self.internal.borrow_mut();
 
         let id = match &internal.keyboard_focus_widget {
@@ -446,7 +455,9 @@ impl Context {
         state.characters.push(c);
     }
 
-    pub(crate) fn set_mouse_pos(&mut self, pos: Point) {
+    /// Set mouse position. 
+    /// You need to take into account the scale factor when setting this. (see `demo_glium.rs`).
+    pub fn set_mouse_pos(&mut self, pos: Point) {
         let mut internal = self.internal.borrow_mut();
         internal.mouse_pos = pos;
     }

--- a/src/gl_backend/mod.rs
+++ b/src/gl_backend/mod.rs
@@ -1,0 +1,549 @@
+use crate::font::{Font, FontSource, FontTextureWriter};
+use crate::image::ImageDrawParams;
+use crate::render::{
+    view_matrix, DrawList, DrawMode, FontHandle, Renderer, TexCoord, TextureData, TextureHandle,
+};
+use crate::theme_definition::CharacterRange;
+use crate::{Color, Frame, Point, Rect};
+
+use gl;
+
+mod program;
+use program::Program;
+
+mod texture;
+use texture::GLTexture;
+
+mod vertex_buffer;
+use vertex_buffer::VAO;
+
+/// A Thyme [`Renderer`](trait.Renderer.html) for [`Glium`](https://github.com/glium/glium).
+///
+/// This adapter registers image and font data as OpenGL textures using gl-rs, and renders each frame.
+/// After the UI has been built, the [`Frame`](struct.Frame.html) should be passed to the renderer
+/// for drawing.
+///
+/// Fonts are prerendered to a texture on the GPU, based on the ttf
+/// font data and the theme specified size.
+///
+/// Data is structured to minimize number of draw calls, with one to three draw calls per render group
+/// (created with [`WidgetBuilder.new_render_group`](struct.WidgetBuilder.html#method.new_render_group))
+/// being typical.  Unless you need UI groups where different widgets may overlap and change draw
+/// ordering frame-by-frame, a single render group will usually be enough for most of your UI.
+///
+/// Widget clipping is handled using `gl::CLIP_DISTANCE0` to `gl::CLIP_DISTANCE3`, again to minimize draw calls.  Since the data to send
+/// to the GPU is constructed each frame in the immediate mode UI model, the amount of data is minimized
+/// by sending only a single `Vertex` for each Image, with the vertex components including the rectangular position and
+/// texture coordinates.  The actual individual on-screen vertices are then constructed with a Geometry shader.
+pub struct GLRenderer {
+    base_program: Program,
+    font_program: Program,
+
+    // assets loaded from the context
+    textures: Vec<GLTexture>,
+    fonts: Vec<GLTexture>,
+
+    // per frame data
+    draw_list: GLDrawList,
+    groups: Vec<DrawGroup>,
+    matrix: [[f32; 4]; 4],
+}
+
+impl GLRenderer {
+    /// Creates a GLRenderer
+    pub fn new() -> GLRenderer {
+        let base_program = Program::new(VERT_SHADER_SRC, GEOM_SHADER_SRC, FRAGMENT_SHADER_SRC);
+
+        let font_program = Program::new(VERT_SHADER_SRC, GEOM_SHADER_SRC, FONT_FRAGMENT_SHADER_SRC);
+
+        GLRenderer {
+            base_program,
+            font_program,
+            fonts: Vec::new(),
+            textures: Vec::new(),
+            draw_list: GLDrawList::new(),
+            groups: Vec::new(),
+            matrix: view_matrix(Point::default(), Point { x: 100.0, y: 100.0 }),
+        }
+    }
+
+    fn font(&self, font: FontHandle) -> &GLTexture {
+        &self.fonts[font.id()]
+    }
+
+    fn texture(&self, texture: TextureHandle) -> &GLTexture {
+        &self.textures[texture.id()]
+    }
+
+    /// Clears the screen with this color.
+    pub fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
+        unsafe {
+            gl::ClearColor(r, g, b, a);
+            gl::Clear(gl::COLOR_BUFFER_BIT);
+        }
+    }
+
+    /// Draws the specified [`Frame`](struct.Frame.html) to the Glium surface, usually the Glium Frame.
+    pub fn draw_frame(&mut self, frame: Frame) {
+        let mouse_cursor = frame.mouse_cursor();
+        let (context, widgets, render_groups) = frame.finish_frame();
+        let context = context.internal().borrow();
+
+        let time_millis = context.time_millis();
+        let display_pos = Point::default();
+        let display_size = context.display_size();
+        let scale = context.scale_factor();
+        self.matrix = view_matrix(display_pos, display_size);
+
+        self.draw_list.clear();
+        self.groups.clear();
+
+        unsafe {
+            gl::Enable(gl::BLEND);
+            gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+            gl::Enable(gl::CLIP_DISTANCE0);
+            gl::Enable(gl::CLIP_DISTANCE1);
+            gl::Enable(gl::CLIP_DISTANCE2);
+            gl::Enable(gl::CLIP_DISTANCE3);
+        }
+
+        for render_group in render_groups.into_iter().rev() {
+            let mut draw_mode = None;
+
+            // render backgrounds
+            for widget in render_group.iter(&widgets) {
+                if !widget.visible() {
+                    continue;
+                }
+                let image_handle = match widget.background() {
+                    None => continue,
+                    Some(handle) => handle,
+                };
+                let time_millis = time_millis - context.base_time_millis_for(widget.id());
+                let image = context.themes().image(image_handle);
+
+                self.write_group_if_changed(&mut draw_mode, DrawMode::Image(image.texture()));
+
+                image.draw(
+                    &mut self.draw_list,
+                    ImageDrawParams {
+                        pos: widget.pos().into(),
+                        size: widget.size().into(),
+                        anim_state: widget.anim_state(),
+                        clip: widget.clip(),
+                        time_millis,
+                        scale,
+                    },
+                );
+            }
+
+            // render foregrounds & text
+            for widget in render_group.iter(&widgets) {
+                if !widget.visible() {
+                    continue;
+                }
+
+                let border = widget.border();
+                let fg_pos = widget.pos() + border.tl();
+                let fg_size = widget.inner_size();
+
+                if let Some(image_handle) = widget.foreground() {
+                    let time_millis = time_millis - context.base_time_millis_for(widget.id());
+                    let image = context.themes().image(image_handle);
+                    self.write_group_if_changed(&mut draw_mode, DrawMode::Image(image.texture()));
+
+                    image.draw(
+                        &mut self.draw_list,
+                        ImageDrawParams {
+                            pos: fg_pos.into(),
+                            size: fg_size.into(),
+                            anim_state: widget.anim_state(),
+                            clip: widget.clip(),
+                            time_millis,
+                            scale,
+                        },
+                    );
+                }
+
+                if let Some(text) = widget.text() {
+                    if let Some(font_sum) = widget.font() {
+                        self.write_group_if_changed(
+                            &mut draw_mode,
+                            DrawMode::Font(font_sum.handle),
+                        );
+                        let font = context.themes().font(font_sum.handle);
+
+                        font.draw(
+                            &mut self.draw_list,
+                            fg_size * scale,
+                            (fg_pos * scale).into(),
+                            text,
+                            widget.text_align(),
+                            widget.text_color(),
+                            widget.clip() * scale,
+                        )
+                    }
+                }
+            }
+
+            // render anything from the final draw calls
+            if let Some(mode) = draw_mode {
+                self.write_group(mode);
+            }
+        }
+
+        if let Some((mouse_cursor, align, anim_state)) = mouse_cursor {
+            let image = context.themes().image(mouse_cursor);
+            let mouse_pos = context.mouse_pos();
+            let size = image.base_size();
+            let pos = mouse_pos - align.adjust_for(size);
+            let clip = Rect::new(pos, size);
+
+            let params = ImageDrawParams {
+                pos: pos.into(),
+                size: size.into(),
+                anim_state,
+                clip,
+                time_millis,
+                scale,
+            };
+
+            image.draw(&mut self.draw_list, params);
+            self.write_group(DrawMode::Image(image.texture()));
+        }
+
+        unsafe {
+            gl::Enable(gl::FRAMEBUFFER_SRGB);
+        }
+        // create the vertex buffer and draw all groups
+        let vao = VAO::new(&self.draw_list.vertices);
+        vao.bind();
+
+        let font_uniform_tex = self.font_program.get_uniform_location("tex");
+        let font_uniform_matrix = self.font_program.get_uniform_location("matrix");
+
+        let base_uniform_tex = self.base_program.get_uniform_location("tex");
+        let base_uniform_matrix = self.base_program.get_uniform_location("matrix");
+
+        for group in &self.groups {
+            match group.mode {
+                DrawMode::Font(font_handle) => {
+                    let font = self.font(font_handle);
+
+                    font.bind(0);
+                    self.font_program.use_program();
+
+                    self.font_program
+                        .uniform_matrix4fv(font_uniform_matrix, false, &self.matrix);
+                    self.font_program.uniform1i(font_uniform_tex, 0);
+
+                    unsafe {
+                        gl::DrawArrays(gl::POINTS, group.start as _, (group.end - group.start) as _)
+                    };
+                }
+                DrawMode::Image(tex_handle) => {
+                    let texture = self.texture(tex_handle);
+
+                    texture.bind(0);
+                    self.base_program.use_program();
+
+                    self.base_program.uniform1i(base_uniform_tex, 0);
+                    self.base_program
+                        .uniform_matrix4fv(base_uniform_matrix, false, &self.matrix);
+
+                    unsafe {
+                        gl::Disable(gl::FRAMEBUFFER_SRGB);
+                    }
+                    unsafe {
+                        gl::DrawArrays(gl::POINTS, group.start as _, (group.end - group.start) as _)
+                    };
+                }
+            };
+        }
+    }
+
+    fn write_group_if_changed(&mut self, mode: &mut Option<DrawMode>, desired_mode: DrawMode) {
+        match mode {
+            None => *mode = Some(desired_mode),
+            Some(cur_mode) => {
+                if *cur_mode != desired_mode {
+                    self.write_group(*cur_mode);
+                    *mode = Some(desired_mode);
+                }
+            }
+        }
+    }
+
+    fn write_group(&mut self, mode: DrawMode) {
+        let end = self.draw_list.vertices.len();
+        // if this is the first draw group, start at 0
+        let start = match self.groups.last() {
+            None => 0,
+            Some(group) => group.end,
+        };
+        self.groups.push(DrawGroup { start, end, mode });
+    }
+}
+
+impl Renderer for GLRenderer {
+    fn register_texture(
+        &mut self,
+        handle: TextureHandle,
+        image_data: &[u8],
+        dimensions: (u32, u32),
+    ) -> Result<TextureData, crate::Error> {
+        let gl_texture = GLTexture::new(
+            image_data,
+            dimensions,
+            gl::LINEAR,
+            gl::CLAMP_TO_EDGE,
+            gl::RGBA,
+            gl::RGBA8,
+        );
+
+        assert!(handle.id() <= self.textures.len());
+        if handle.id() == self.textures.len() {
+            self.textures.push(gl_texture);
+        } else {
+            self.textures[handle.id()] = gl_texture;
+        }
+
+        Ok(TextureData::new(handle, dimensions.0, dimensions.1))
+    }
+
+    fn register_font(
+        &mut self,
+        handle: FontHandle,
+        source: &FontSource,
+        ranges: &[CharacterRange],
+        size: f32,
+        scale: f32,
+    ) -> Result<Font, crate::Error> {
+        let font = &source.font;
+
+        let writer = FontTextureWriter::new(font, ranges, size, scale);
+
+        let writer_out = writer.write(handle, ranges)?;
+
+        let font_texture = GLTexture::new(
+            &writer_out.data,
+            (writer_out.tex_width, writer_out.tex_height),
+            gl::NEAREST,
+            gl::CLAMP_TO_BORDER,
+            gl::RED,
+            gl::R8,
+        );
+
+        assert!(handle.id() <= self.fonts.len());
+        if handle.id() == self.fonts.len() {
+            self.fonts.push(font_texture);
+        } else {
+            self.fonts[handle.id()] = font_texture;
+        }
+
+        Ok(writer_out.font)
+    }
+}
+
+struct DrawGroup {
+    start: usize,
+    end: usize,
+    mode: DrawMode,
+}
+
+// Pass through the vertex to the geometry shader where the rectangle is built
+const VERT_SHADER_SRC: &str = r#"
+  #version 330
+
+  layout(location = 0) in vec2 position;
+  layout(location = 1) in vec2 size;
+  layout(location = 2) in vec2 tex0;
+  layout(location = 3) in vec2 tex1;
+  layout(location = 4) in vec3 color;
+  layout(location = 5) in vec2 clip_pos;
+  layout(location = 6) in vec2 clip_size;
+
+  out vec2 g_size;
+  out vec2 g_tex0;
+  out vec2 g_tex1;
+  out vec3 g_color;
+  out vec2 g_clip_pos;
+  out vec2 g_clip_size;
+
+  void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+	
+	g_size = size;
+	g_tex0 = tex0;
+	g_tex1 = tex1;
+	g_color = color;
+	g_clip_pos = clip_pos;
+	g_clip_size = clip_size;
+  }
+"#;
+
+const GEOM_SHADER_SRC: &str = r#"
+  #version 150
+
+  layout (points) in;
+  layout (triangle_strip, max_vertices = 4) out;
+
+  in vec2 g_size[];
+  in vec2 g_tex0[];
+  in vec2 g_tex1[];
+  in vec3 g_color[];
+  in vec2 g_clip_pos[];
+  in vec2 g_clip_size[];
+
+  out vec2 v_tex_coords;
+  out vec3 v_color;
+
+  uniform mat4 matrix;
+
+  void main() {
+	vec4 base = gl_in[0].gl_Position;
+    
+    vec2 clip_pos = g_clip_pos[0];
+    vec2 clip_size = g_clip_size[0];
+
+    // draw the rectangle using 2 triangles in triangle_strip
+
+    // [0, 0] vertex
+    vec4 position = base;
+    gl_ClipDistance[0] = position.x - clip_pos.x;
+    gl_ClipDistance[1] = clip_pos.x + clip_size.x - position.x;
+    gl_ClipDistance[2] = position.y - clip_pos.y;
+    gl_ClipDistance[3] = clip_pos.y + clip_size.y - position.y;
+	gl_Position = matrix * position;
+	v_tex_coords = g_tex0[0];
+	v_color = g_color[0];
+	EmitVertex();
+    
+    // [0, 1] vertex
+    position = base + vec4(0.0, g_size[0].y, 0.0, 0.0);
+    gl_ClipDistance[0] = position.x - clip_pos.x;
+    gl_ClipDistance[1] = clip_pos.x + clip_size.x - position.x;
+    gl_ClipDistance[2] = position.y - clip_pos.y;
+    gl_ClipDistance[3] = clip_pos.y + clip_size.y - position.y;
+	gl_Position = matrix * position;
+	v_tex_coords = vec2(g_tex0[0].x, g_tex1[0].y);
+	v_color = g_color[0];
+    EmitVertex();
+    
+    // [1, 0] vertex
+    position = base + vec4(g_size[0].x, 0.0, 0.0, 0.0);
+	gl_ClipDistance[0] = position.x - clip_pos.x;
+    gl_ClipDistance[1] = clip_pos.x + clip_size.x - position.x;
+    gl_ClipDistance[2] = position.y - clip_pos.y;
+    gl_ClipDistance[3] = clip_pos.y + clip_size.y - position.y;
+	gl_Position = matrix * position;
+	v_tex_coords = vec2(g_tex1[0].x, g_tex0[0].y);
+	v_color = g_color[0];
+    EmitVertex();
+    
+    // [1, 1] vertex
+    position = base + vec4(g_size[0].x, g_size[0].y, 0.0, 0.0);
+    gl_ClipDistance[0] = position.x - clip_pos.x;
+    gl_ClipDistance[1] = clip_pos.x + clip_size.x - position.x;
+    gl_ClipDistance[2] = position.y - clip_pos.y;
+    gl_ClipDistance[3] = clip_pos.y + clip_size.y - position.y;
+    gl_Position = matrix * position;
+    v_tex_coords = g_tex1[0];
+    v_color = g_color[0];
+    EmitVertex();
+
+    EndPrimitive();
+  }
+"#;
+
+const FRAGMENT_SHADER_SRC: &str = r#"
+  #version 150
+
+  in vec2 v_tex_coords;
+  in vec3 v_color;
+
+  out vec4 color;
+
+  uniform sampler2D tex;
+
+  void main() {
+    color = vec4(v_color, 1.0) * texture(tex, v_tex_coords);
+  }
+"#;
+
+const FONT_FRAGMENT_SHADER_SRC: &str = r#"
+    #version 150
+
+    in vec2 v_tex_coords;
+    in vec3 v_color;
+
+    out vec4 color;
+
+    uniform sampler2D tex;
+    
+    void main() {
+        color = vec4(v_color, texture(tex, v_tex_coords).r);
+    }
+"#;
+
+struct GLDrawList {
+    vertices: Vec<GLVertex>,
+}
+
+impl GLDrawList {
+    fn new() -> Self {
+        GLDrawList {
+            vertices: Vec::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.vertices.clear();
+    }
+}
+
+impl DrawList for GLDrawList {
+    fn len(&self) -> usize {
+        self.vertices.len()
+    }
+
+    fn back_adjust_positions(&mut self, since_index: usize, amount: Point) {
+        for vert in self.vertices.iter_mut().skip(since_index) {
+            vert.position[0] += amount.x;
+            vert.position[1] += amount.y;
+        }
+    }
+
+    fn push_rect(
+        &mut self,
+        pos: [f32; 2],
+        size: [f32; 2],
+        tex: [TexCoord; 2],
+        color: Color,
+        clip: Rect,
+    ) {
+        let vert = GLVertex {
+            position: pos,
+            size,
+            tex0: [tex[0].x(), tex[0].y()],
+            tex1: [tex[1].x(), tex[1].y()],
+            color: color.into(),
+            clip_pos: clip.pos.into(),
+            clip_size: clip.size.into(),
+        };
+
+        self.vertices.push(vert);
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub(crate) struct GLVertex {
+    pub position: [f32; 2],
+    pub size: [f32; 2],
+    pub tex0: [f32; 2],
+    pub tex1: [f32; 2],
+    pub color: [f32; 3],
+    pub clip_pos: [f32; 2],
+    pub clip_size: [f32; 2],
+}

--- a/src/gl_backend/program.rs
+++ b/src/gl_backend/program.rs
@@ -1,0 +1,88 @@
+use gl;
+pub struct Program {
+    program_handle: u32,
+}
+
+impl Program {
+    pub fn new(vertex_shader: &str, geom_shader: &str, fragment_shader: &str) -> Program {
+        let program_handle = unsafe { gl::CreateProgram() };
+
+        let vertex_shader = unsafe { create_shader(gl::VERTEX_SHADER, vertex_shader) };
+        let geom_shader = unsafe { create_shader(gl::GEOMETRY_SHADER, geom_shader) };
+        let fragment_shader = unsafe { create_shader(gl::FRAGMENT_SHADER, fragment_shader) };
+
+        unsafe {
+            gl::AttachShader(program_handle, vertex_shader);
+            gl::AttachShader(program_handle, geom_shader);
+            gl::AttachShader(program_handle, fragment_shader);
+
+            gl::LinkProgram(program_handle);
+
+            gl::DeleteShader(vertex_shader);
+            gl::DeleteShader(geom_shader);
+            gl::DeleteShader(fragment_shader);
+        }
+
+        Program { program_handle }
+    }
+
+    pub fn uniform_matrix4fv(
+        &self,
+        uniform_location: i32,
+        transposed: bool,
+        matrix: &[[f32; 4]; 4],
+    ) {
+        let transposed = if transposed { 1 } else { 0 };
+        unsafe {
+            gl::UniformMatrix4fv(uniform_location, 1, transposed, matrix.as_ptr() as _);
+        }
+    }
+
+    pub fn uniform1i(&self, uniform_location: i32, value: i32) {
+        unsafe {
+            gl::Uniform1i(uniform_location, value);
+        }
+    }
+
+    pub fn get_uniform_location(&self, name: &str) -> i32 {
+        let name = std::ffi::CString::new(name).unwrap();
+        unsafe { gl::GetUniformLocation(self.program_handle, name.as_ptr() as _) }
+    }
+
+    pub fn use_program(&self) {
+        unsafe {
+            gl::UseProgram(self.program_handle);
+        }
+    }
+}
+
+unsafe fn create_shader(shader_type: u32, src: &str) -> u32 {
+    let shader_str = std::ffi::CString::new(src).unwrap();
+    
+    let gl_handle = gl::CreateShader(shader_type);
+    gl::ShaderSource(gl_handle, 1, &shader_str.as_ptr() as _, std::ptr::null());
+    gl::CompileShader(gl_handle);
+
+    let mut success = gl::FALSE as gl::types::GLint;
+    gl::GetShaderiv(gl_handle, gl::COMPILE_STATUS, &mut success);
+    if success != gl::TRUE as gl::types::GLint {
+        let info_log = [0u8; 513];
+        let mut error_size = 0i32;
+        gl::GetShaderInfoLog(gl_handle, 512, &mut error_size, info_log.as_ptr() as _);
+        let info_log = std::str::from_utf8(&info_log[..error_size as usize]);
+        panic!(
+            "Error compile failed with error: {:?} for: {:?}",
+            info_log, gl_handle
+        );
+    }
+
+    gl_handle
+}
+
+impl Drop for Program {
+    fn drop(&mut self) {
+        unsafe {
+            gl::DeleteProgram(self.program_handle);
+        }
+    }
+}

--- a/src/gl_backend/texture.rs
+++ b/src/gl_backend/texture.rs
@@ -1,0 +1,85 @@
+pub struct GLTexture {
+    texture_handle: u32,
+    data: Vec<u8>,
+}
+
+impl GLTexture {
+    pub fn new(
+        image_data: &[u8],
+        dimensions: (u32, u32),
+        filter: u32,
+        wrap: u32,
+        format: u32,
+        internal_format: u32,
+    ) -> GLTexture {
+        let mut texture = GLTexture {
+            texture_handle: 0,
+            data: image_data.to_vec(),
+        };
+        
+        unsafe {
+            gl::GenTextures(1, &mut texture.texture_handle);
+            gl::BindTexture(gl::TEXTURE_2D, texture.texture_handle);
+
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, wrap as _);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, wrap as _);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_R, wrap as _);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, filter as _);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, filter as _);
+
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_BASE_LEVEL, 0);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAX_LEVEL, 0);
+            gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
+            
+            gl::TexStorage2D(
+                gl::TEXTURE_2D,
+                1,
+                internal_format as _,
+                dimensions.0 as _,
+                dimensions.1 as _,
+            );
+            
+            gl::TexSubImage2D(
+                gl::TEXTURE_2D,
+                0,
+                0,
+                0,
+                dimensions.0 as _,
+                dimensions.1 as _,
+                format,
+                gl::UNSIGNED_BYTE,
+                texture.data.as_ptr() as _,
+            );
+
+            gl::GenerateMipmap(gl::TEXTURE_2D);
+        }
+
+        texture
+    }
+
+    pub fn bind(&self, idx: i32) {
+        let bind_location = match idx {
+            0 => gl::TEXTURE0,
+            1 => gl::TEXTURE1,
+            2 => gl::TEXTURE2,
+            3 => gl::TEXTURE3,
+            4 => gl::TEXTURE4,
+            5 => gl::TEXTURE5,
+            6 => gl::TEXTURE6,
+            _ => panic!("invalid idx"),
+        };
+
+        unsafe {
+            gl::ActiveTexture(bind_location);
+            gl::BindTexture(gl::TEXTURE_2D, self.texture_handle);
+        }
+    }
+}
+
+impl Drop for GLTexture {
+    fn drop(&mut self) {
+        unsafe {
+            gl::DeleteTextures(1, &self.texture_handle);
+        }
+    }
+}

--- a/src/gl_backend/vertex_buffer.rs
+++ b/src/gl_backend/vertex_buffer.rs
@@ -1,0 +1,121 @@
+use super::GLVertex;
+use gl;
+use memoffset::offset_of;
+
+pub struct VAO {
+    vao_handle: u32,
+    vbo_handle: u32,
+}
+
+impl VAO {
+    pub(crate) fn new(vertices: &[GLVertex]) -> VAO {
+        let mut vao_handle = 0;
+        let mut vbo_handle = 0;
+        unsafe {
+            gl::GenVertexArrays(1, &mut vao_handle);
+           
+            gl::GenBuffers(1, &mut vbo_handle);
+            // bind the Vertex Array Object first, then bind and set vertex buffer(s), and then configure vertex attributes(s).
+            gl::BindVertexArray(vao_handle);
+
+            gl::BindBuffer(gl::ARRAY_BUFFER, vbo_handle);
+            gl::BufferData(
+                gl::ARRAY_BUFFER,
+                (vertices.len() * std::mem::size_of::<GLVertex>()) as _,
+                vertices.as_ptr() as _,
+                gl::STATIC_DRAW,
+            );
+
+            for idx in 0..=6 {
+                gl::EnableVertexAttribArray(idx);    
+            }
+            
+            gl::VertexAttribPointer(
+                0,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, position) as _,
+            );
+
+            gl::VertexAttribPointer(
+                1,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, size) as _,
+            );
+
+            gl::VertexAttribPointer(
+                2,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, tex0) as _,
+            );
+
+            gl::VertexAttribPointer(
+                3,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, tex1) as _,
+            );
+
+            gl::VertexAttribPointer(
+                4,
+                3,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, color) as _,
+            );
+
+            gl::VertexAttribPointer(
+                5,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, clip_pos) as _,
+            );
+
+            gl::VertexAttribPointer(
+                6,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                std::mem::size_of::<GLVertex>() as _,
+                offset_of!(GLVertex, clip_size) as _,
+            );
+            
+
+            gl::BindBuffer(gl::ARRAY_BUFFER, 0);
+            gl::BindVertexArray(0);
+        }
+
+        VAO {
+            vao_handle,
+            vbo_handle,
+        }
+    }
+
+    pub fn bind(&self) {
+        unsafe {
+            gl::BindVertexArray(self.vao_handle);
+        }
+    }
+}
+
+impl Drop for VAO {
+    fn drop(&mut self) {
+        unsafe {
+            gl::DeleteBuffers(1, &self.vbo_handle);
+            gl::DeleteVertexArrays(1, &self.vao_handle);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,13 @@ pub use app_builder::AppBuilder;
 #[cfg(feature="glium_backend")]
 pub use app_builder::GliumApp;
 
+#[cfg(feature = "gl_backend")]
+mod gl_backend;
+
+#[cfg(feature = "gl_backend")]
+pub use gl_backend::GLRenderer;
+
+
 pub use frame::Frame;
 pub use point::{Rect, Point, Border};
 pub use widget::{WidgetBuilder, WidgetState};


### PR DESCRIPTION
Hello,

Thanks for your efforts on this library, it looks quite the promissing compromise between the niceness of an immediate-mode ui and the requirements one might have for a game UI library.

I've opened this issue a while back, and decided to add gl-rs: https://github.com/Grokmoo/thyme/issues/24

I still think that issue is relevant, as it removes this repository being the bottleneck for various backends.

One thing I had to do, is make more items from Context public, in order to allow me to integarte with SDL for my game (and without requiring an IO for SDL as the one for winit is the crate).

I believe emgui (my library of choice for debug ui or level editor) seems to have a more modular approach to integrations and it would benefit to get some inspiration from egui approaches integrations.

Key things I noticed but didn't fix and could be addressed in a follow-up PR:
- Mouse buttons IDs are integers. That may have been ok-ish for internal use, but I had to make the method public so we can probably use an enum there?
- The IO trait may benefit of being extended with an `add_event` function. Right now, the trait it has just ui_scale and resolution methods. This also means getting an thyme::Event exposed (that's not the winit one).
- Would be good to drop the reliance on geometry shaders so we could emit vertices on the CPU (in that way we can emmit them regardless of the backend. e.g. as all graphics APIs are public and geometry shaders are problematic http://www.joshbarczak.com/blog/?p=667 and https://static.docs.arm.com/100019/0100/arm_mali_application_developer_best_practices_developer_guide_100019_0100_00_en2.pdf see chapter on avoiding geom. shaders on page 19). This would also simplify the backend pipelines.